### PR TITLE
Adding initial delay

### DIFF
--- a/src/Stepper.cpp
+++ b/src/Stepper.cpp
@@ -178,6 +178,30 @@ void Stepper::setSpeed(long whatSpeed)
 }
 
 /*
+* Sets initial delay in us to prevent unexpected behaviour in the start 
+*/
+void Stepper::initializeWithDelay(unsigned long initial_delay)
+{
+  //first the motor is enabled on its first step
+  stepMotor(0);
+  
+  if(initial_delay <= this->step_delay)
+  {
+    /*if the intial delay is smaller than the step_ delay the motor 
+    * is only enabled and the current time is saved.
+    */
+    this->last_step_time = micros() ;
+  } 
+  else
+  {
+    /*if the delay is bigger than the step_delay the difference is added to 
+    * the saved time to postpone the next step. 
+    */
+    this->last_step_time = micros() + initial_delay - this->step_delay;
+  }
+}
+
+/*
  * Moves the motor steps_to_move steps.  If the number is negative,
  * the motor moves in the reverse direction.
  */


### PR DESCRIPTION
When a stepper motor is turned on it is possible the rotor is not lined up with the magnetic field. In these first few moments of initializing the motor will line up again. This process takes some time; if you start controlling the motor within this time you can get unexpected behaviour. The problem is that the unallingment is everytime different therefore it can happen that one time a profile works and another time it wont.

I had a lot of problems with this effect. I edited this library to have a starting delay after initializing and got my project to work.

This requested has already been listed at https://github.com/arduino/Arduino/pull/5813 but is now moved to here as requested.