### PR TITLE
Add 4-wire 8-step Support for 28BYJ-48 Motor

### DIFF
--- a/examples/MotorKnob/MotorKnob.ino
+++ b/examples/MotorKnob/MotorKnob.ino
@@ -24,6 +24,10 @@ int previous = 0;
 void setup() {
   // set the speed of the motor to 30 RPMs
   stepper.setSpeed(30);
+
+  // uncomment this line if using a motor with an 8-beat pattern,
+  // like the 28BY-J-48 4-wire motor.
+  // stepper.setBeatsPerPattern(8);
 }
 
 void loop() {

--- a/examples/stepper_oneRevolution/stepper_oneRevolution.ino
+++ b/examples/stepper_oneRevolution/stepper_oneRevolution.ino
@@ -26,6 +26,11 @@ Stepper myStepper(stepsPerRevolution, 8, 9, 10, 11);
 void setup() {
   // set the speed at 60 rpm:
   myStepper.setSpeed(60);
+
+  // uncomment this line if using a motor with an 8-beat pattern,
+  // like the 28BY-J-48 4-wire motor.
+  // stepper.setBeatsPerPattern(8);
+
   // initialize the serial port:
   Serial.begin(9600);
 }

--- a/examples/stepper_oneStepAtATime/stepper_oneStepAtATime.ino
+++ b/examples/stepper_oneStepAtATime/stepper_oneStepAtATime.ino
@@ -31,6 +31,10 @@ int stepCount = 0;         // number of steps the motor has taken
 void setup() {
   // initialize the serial port:
   Serial.begin(9600);
+
+  // uncomment this line if using a motor with an 8-beat pattern,
+  // like the 28BY-J-48 4-wire motor.
+  // stepper.setBeatsPerPattern(8);
 }
 
 void loop() {

--- a/examples/stepper_speedControl/stepper_speedControl.ino
+++ b/examples/stepper_speedControl/stepper_speedControl.ino
@@ -29,7 +29,9 @@ Stepper myStepper(stepsPerRevolution, 8, 9, 10, 11);
 int stepCount = 0;  // number of steps the motor has taken
 
 void setup() {
-  // nothing to do inside the setup
+  // uncomment this line if using a motor with an 8-beat pattern,
+  // like the 28BY-J-48 4-wire motor.
+  // stepper.setBeatsPerPattern(8);
 }
 
 void loop() {

--- a/src/Stepper.cpp
+++ b/src/Stepper.cpp
@@ -88,6 +88,7 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2)
   this->direction = 0;      // motor direction
   this->last_step_time = 0; // time stamp in us of the last step taken
   this->number_of_steps = number_of_steps; // total number of steps for this motor
+  this->beats_per_pattern = 2;
 
   // Arduino pins for the motor control connection:
   this->motor_pin_1 = motor_pin_1;
@@ -118,6 +119,7 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2,
   this->direction = 0;      // motor direction
   this->last_step_time = 0; // time stamp in us of the last step taken
   this->number_of_steps = number_of_steps; // total number of steps for this motor
+  this->beats_per_pattern = 4;
 
   // Arduino pins for the motor control connection:
   this->motor_pin_1 = motor_pin_1;
@@ -150,6 +152,7 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2,
   this->direction = 0;      // motor direction
   this->last_step_time = 0; // time stamp in us of the last step taken
   this->number_of_steps = number_of_steps; // total number of steps for this motor
+  this->beats_per_pattern = 10;
 
   // Arduino pins for the motor control connection:
   this->motor_pin_1 = motor_pin_1;
@@ -167,6 +170,21 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2,
 
   // pin_count is used by the stepMotor() method:
   this->pin_count = 5;
+}
+
+/*
+ * Select the number of beats in the stepper motor pattern.
+ * For four-wire motors, this can be either four or eight.
+ * For two and five wire motors, the number of beats cannot be changed.
+ */
+
+void Stepper::setBeatsPerPattern( int beats )
+{
+	if(pin_count==4 && (beats==4) || (beats==8)) {
+		beats_per_pattern = beats;
+	} else {
+		// Illegal combination
+	}
 }
 
 /*
@@ -218,10 +236,7 @@ void Stepper::step(int steps_to_move)
       // decrement the steps left:
       steps_left--;
       // step the motor to step number 0, 1, ..., {3 or 10}
-      if (this->pin_count == 5)
-        stepMotor(this->step_number % 10);
-      else
-        stepMotor(this->step_number % 4);
+      stepMotor(this->step_number % this->beats_per_pattern);
     }
   }
 }
@@ -251,7 +266,7 @@ void Stepper::stepMotor(int thisStep)
       break;
     }
   }
-  if (this->pin_count == 4) {
+  if (this->pin_count == 4 && this->beats_per_pattern==4) {
     switch (thisStep) {
       case 0:  // 1010
         digitalWrite(motor_pin_1, HIGH);
@@ -272,6 +287,59 @@ void Stepper::stepMotor(int thisStep)
         digitalWrite(motor_pin_4, HIGH);
       break;
       case 3:  //1001
+        digitalWrite(motor_pin_1, HIGH);
+        digitalWrite(motor_pin_2, LOW);
+        digitalWrite(motor_pin_3, LOW);
+        digitalWrite(motor_pin_4, HIGH);
+      break;
+    }
+  }
+
+  if (this->pin_count == 4 && this->beats_per_pattern==8) {
+    switch (thisStep) {
+      case 0:
+        digitalWrite(motor_pin_1, HIGH);
+        digitalWrite(motor_pin_2, LOW);
+        digitalWrite(motor_pin_3, LOW);
+        digitalWrite(motor_pin_4, LOW);
+      break;
+      case 1:
+        digitalWrite(motor_pin_1, HIGH);
+        digitalWrite(motor_pin_2, HIGH);
+        digitalWrite(motor_pin_3, LOW);
+        digitalWrite(motor_pin_4, LOW);
+      break;
+      case 2:
+        digitalWrite(motor_pin_1, LOW);
+        digitalWrite(motor_pin_2, HIGH);
+        digitalWrite(motor_pin_3, LOW);
+        digitalWrite(motor_pin_4, LOW);
+      break;
+      case 3:
+        digitalWrite(motor_pin_1, LOW);
+        digitalWrite(motor_pin_2, HIGH);
+        digitalWrite(motor_pin_3, HIGH);
+        digitalWrite(motor_pin_4, LOW);
+      break;
+      case 4:
+        digitalWrite(motor_pin_1, LOW);
+        digitalWrite(motor_pin_2, LOW);
+        digitalWrite(motor_pin_3, HIGH);
+        digitalWrite(motor_pin_4, LOW);
+      break;
+      case 5:
+        digitalWrite(motor_pin_1, LOW);
+        digitalWrite(motor_pin_2, LOW);
+        digitalWrite(motor_pin_3, HIGH);
+        digitalWrite(motor_pin_4, HIGH);;
+      break;
+      case 6:
+        digitalWrite(motor_pin_1, LOW);
+        digitalWrite(motor_pin_2, LOW);
+        digitalWrite(motor_pin_3, LOW);
+        digitalWrite(motor_pin_4, HIGH);
+      break;
+      case 7:
         digitalWrite(motor_pin_1, HIGH);
         digitalWrite(motor_pin_2, LOW);
         digitalWrite(motor_pin_3, LOW);
@@ -361,5 +429,5 @@ void Stepper::stepMotor(int thisStep)
 */
 int Stepper::version(void)
 {
-  return 5;
+  return 6;
 }

--- a/src/Stepper.cpp
+++ b/src/Stepper.cpp
@@ -53,13 +53,26 @@
  *    9  1  0  1  0  1
  *   10  0  0  1  0  1
  *
- * The sequence of control signals for 4 control wires is as follows:
+ * There are two possible sequences for 4 control wires.
+ * Stepper pattern with four beats (the default) is as follows:
  *
  * Step C0 C1 C2 C3
  *    1  1  0  1  0
  *    2  0  1  1  0
  *    3  0  1  0  1
  *    4  1  0  0  1
+ *
+ * Stepper pattern with eight half steps is as follows:
+ *
+ * Step C0 C1 C2 C3
+ *    1  1  0  0  0
+ *    2  1  1  0  0
+ *    3  0  1  0  0
+ *    4  0  1  1  0
+ *    5  0  0  1  0
+ *    6  0  0  1  1
+ *    7  0  0  0  1
+ *    8  1  0  0  1
  *
  * The sequence of controls signals for 2 control wires is as follows
  * (columns C1 and C2 from above):

--- a/src/Stepper.h
+++ b/src/Stepper.h
@@ -53,13 +53,26 @@
  *    9  1  0  1  0  1
  *   10  0  0  1  0  1
  *
- * The sequence of control signals for 4 control wires is as follows:
+ * There are two possible sequences for 4 control wires.
+ * Stepper pattern with four beats (the default) is as follows:
  *
  * Step C0 C1 C2 C3
  *    1  1  0  1  0
  *    2  0  1  1  0
  *    3  0  1  0  1
  *    4  1  0  0  1
+ *
+ * Stepper pattern with eight half steps is as follows:
+ *
+ * Step C0 C1 C2 C3
+ *    1  1  0  0  0
+ *    2  1  1  0  0
+ *    3  0  1  0  0
+ *    4  0  1  1  0
+ *    5  0  0  1  0
+ *    6  0  0  1  1
+ *    7  0  0  0  1
+ *    8  1  0  0  1
  *
  * The sequence of controls signals for 2 control wires is as follows
  * (columns C1 and C2 from above):
@@ -90,6 +103,9 @@ class Stepper {
                                  int motor_pin_3, int motor_pin_4,
                                  int motor_pin_5);
 
+    // four-wire motors can have either four or eight beats
+    void setBeatsPerPattern( int beats );
+
     // speed setter method:
     void setSpeed(long whatSpeed);
 
@@ -106,6 +122,7 @@ class Stepper {
     int number_of_steps;      // total number of steps this motor can take
     int pin_count;            // how many pins are in use.
     int step_number;          // which step the motor is on
+    int beats_per_pattern;    // number of beats in the motor pattern
 
     // motor pin numbers:
     int motor_pin_1;
@@ -118,4 +135,3 @@ class Stepper {
 };
 
 #endif
-


### PR DESCRIPTION
This PR provides support for 4-wire 8-step motors, such as the 28BYJ-48, which is very widely available now, and not well supported by this library.  To enable the new 8-step pattern, construct the four-wire object as normal, then do this to enable the alternate pattern:
```
stepper.setBeatsPerPattern(8);
```

Behavior is unchanged for existing code and motors.

I confess that the terminology "beats per pattern" is a bit awkward; if anyone has a suggestion on how to more clearly represent this to the user, that would be great.


