### PR TITLE
Yield while stepper motor is stepping

### DIFF
--- a/src/Stepper.cpp
+++ b/src/Stepper.cpp
@@ -222,6 +222,8 @@ void Stepper::step(int steps_to_move)
         stepMotor(this->step_number % 10);
       else
         stepMotor(this->step_number % 4);
+    } else {
+      yield();
     }
   }
 }


### PR DESCRIPTION
This allows the stepper library to be used on ESP8266 and other boards which have a watchdog timer.

Otherwise, a step(100) call will take multiple seconds without yielding, and the watchdog will reset the board.