### PR TITLE
Simplify Stepper::stepMotor()

### DIFF
--- a/src/Stepper.cpp
+++ b/src/Stepper.cpp
@@ -233,128 +233,29 @@ void Stepper::step(int steps_to_move)
  */
 void Stepper::stepMotor(int thisStep)
 {
-  if (this->pin_count == 2) {
-    switch (thisStep) {
-      case 0:  // 01
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, HIGH);
-      break;
-      case 1:  // 11
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, HIGH);
-      break;
-      case 2:  // 10
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, LOW);
-      break;
-      case 3:  // 00
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, LOW);
-      break;
-    }
-  }
-  if (this->pin_count == 4) {
-    switch (thisStep) {
-      case 0:  // 1010
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, LOW);
-        digitalWrite(motor_pin_3, HIGH);
-        digitalWrite(motor_pin_4, LOW);
-      break;
-      case 1:  // 0110
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, HIGH);
-        digitalWrite(motor_pin_3, HIGH);
-        digitalWrite(motor_pin_4, LOW);
-      break;
-      case 2:  //0101
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, HIGH);
-        digitalWrite(motor_pin_3, LOW);
-        digitalWrite(motor_pin_4, HIGH);
-      break;
-      case 3:  //1001
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, LOW);
-        digitalWrite(motor_pin_3, LOW);
-        digitalWrite(motor_pin_4, HIGH);
-      break;
-    }
-  }
+  static PROGMEM const uint8_t phases[] = {
+    LOW, LOW, LOW, LOW, HIGH, HIGH, HIGH, HIGH, HIGH,
+    LOW, LOW, LOW, LOW, LOW, HIGH, HIGH, HIGH, HIGH
+  };
 
-  if (this->pin_count == 5) {
-    switch (thisStep) {
-      case 0:  // 01101
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, HIGH);
-        digitalWrite(motor_pin_3, HIGH);
-        digitalWrite(motor_pin_4, LOW);
-        digitalWrite(motor_pin_5, HIGH);
-        break;
-      case 1:  // 01001
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, HIGH);
-        digitalWrite(motor_pin_3, LOW);
-        digitalWrite(motor_pin_4, LOW);
-        digitalWrite(motor_pin_5, HIGH);
-        break;
-      case 2:  // 01011
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, HIGH);
-        digitalWrite(motor_pin_3, LOW);
-        digitalWrite(motor_pin_4, HIGH);
-        digitalWrite(motor_pin_5, HIGH);
-        break;
-      case 3:  // 01010
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, HIGH);
-        digitalWrite(motor_pin_3, LOW);
-        digitalWrite(motor_pin_4, HIGH);
-        digitalWrite(motor_pin_5, LOW);
-        break;
-      case 4:  // 11010
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, HIGH);
-        digitalWrite(motor_pin_3, LOW);
-        digitalWrite(motor_pin_4, HIGH);
-        digitalWrite(motor_pin_5, LOW);
-        break;
-      case 5:  // 10010
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, LOW);
-        digitalWrite(motor_pin_3, LOW);
-        digitalWrite(motor_pin_4, HIGH);
-        digitalWrite(motor_pin_5, LOW);
-        break;
-      case 6:  // 10110
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, LOW);
-        digitalWrite(motor_pin_3, HIGH);
-        digitalWrite(motor_pin_4, HIGH);
-        digitalWrite(motor_pin_5, LOW);
-        break;
-      case 7:  // 10100
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, LOW);
-        digitalWrite(motor_pin_3, HIGH);
-        digitalWrite(motor_pin_4, LOW);
-        digitalWrite(motor_pin_5, LOW);
-        break;
-      case 8:  // 10101
-        digitalWrite(motor_pin_1, HIGH);
-        digitalWrite(motor_pin_2, LOW);
-        digitalWrite(motor_pin_3, HIGH);
-        digitalWrite(motor_pin_4, LOW);
-        digitalWrite(motor_pin_5, HIGH);
-        break;
-      case 9:  // 00101
-        digitalWrite(motor_pin_1, LOW);
-        digitalWrite(motor_pin_2, LOW);
-        digitalWrite(motor_pin_3, HIGH);
-        digitalWrite(motor_pin_4, LOW);
-        digitalWrite(motor_pin_5, HIGH);
-        break;
-    }
+  switch (pin_count) {
+    case 2:
+      digitalWrite(motor_pin_1, (thisStep+1) & 2);
+      digitalWrite(motor_pin_2, (thisStep+2) & 2);
+    break;
+    case 4:
+      digitalWrite(motor_pin_4, (thisStep+0) & 2);
+      digitalWrite(motor_pin_2, (thisStep+1) & 2);
+      digitalWrite(motor_pin_3, (thisStep+2) & 2);
+      digitalWrite(motor_pin_1, (thisStep+3) & 2);
+    break;
+    case 5:
+      digitalWrite(motor_pin_1, pgm_read_byte(&phases[thisStep+0]));
+      digitalWrite(motor_pin_4, pgm_read_byte(&phases[thisStep+2]));
+      digitalWrite(motor_pin_2, pgm_read_byte(&phases[thisStep+4]));
+      digitalWrite(motor_pin_5, pgm_read_byte(&phases[thisStep+6]));
+      digitalWrite(motor_pin_3, pgm_read_byte(&phases[thisStep+8]));
+    break;
   }
 }
 


### PR DESCRIPTION
The current version of `Stepper::stepMotor()` uses one `switch` statement for each possible `pin_count`, with one `case` per step number, for a total of 18 cases. However, on a stepper motor, all pin signals follow the same periodic pattern, differing only by the initial phase, which suggests the signals could be built algorithmically.

This pull request exploits this fact in order to simplify the code. It shortens the method `Stepper::stepMotor()` by 99 lines. Building MotorKnob.ino for an Uno shows 314 bytes of flash were saved.

Note that, for the 5-pin motors, the pattern is hard-coded in a `PROGMEM` array, although it could be easily generated as

```c++
(thisStep+offset) % 10 >= 5
```

The array method was chosen because, on devices lacking a hardware divider, that modulo operation would be slow. The array only costs 18 bytes of flash, which is small compared to the flash savings achieved.